### PR TITLE
hotfix for loading the recipe box after user login

### DIFF
--- a/assets/javascript/auth.js
+++ b/assets/javascript/auth.js
@@ -179,6 +179,9 @@ firebase.auth().onAuthStateChanged(function(user) {
     fetchRecipes();
     //update the UI with user profile data
     $("#box-click").text(currentUser.displayName);
+    $("#recipe-box")
+      .detach()
+      .appendTo($("#box"));
   } else {
     //this block is reached when the poage loads without a user logged in, or a user signs out, or navigates away from the page, or the tab/window is closed
     //I am unsure of how this code block behaves when the latter of the four conditions is undertaken. Testing is required.

--- a/assets/javascript/logic.js
+++ b/assets/javascript/logic.js
@@ -282,5 +282,11 @@ $(document).on("keyup", function(event) {
 
   if (targetId === "recipe-search") {
     $("#search-icon").trigger("click");
+  } else if (targetId === "sign-in-email") {
+    $("#sign-in-password").focus();
+  } else if (targetId === "sign-in-password") {
+    $("#sign-in").trigger("click");
+  } else if (targetId === "custom-tab-input") {
+    $("#tab-okay-icon").trigger("click");
   }
 });


### PR DESCRIPTION
That annoying empty blue div now holds the recipe box after login, sign up, or guest login.